### PR TITLE
Fix musicbrainzngs support for versions greater than 0.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         'setuptools',
         'Mopidy >= 2.0',
         'Pykka >= 1.1',
-        'musicbrainzngs == 0.6',
+        'musicbrainzngs >= 0.6',
     ],
     entry_points={
         'mopidy.ext': [


### PR DESCRIPTION
As in title.
This enable me to use this plugin on Arch Linux
Regards